### PR TITLE
Make a standalone typescript config file for the frontend part

### DIFF
--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "jsx": "preserve",
+    "skipLibCheck": true,
+    "inlineSourceMap": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "incremental": true
+  },
+  "include": ["./**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     "allowJs": true /* Allow javascript files to be compiled. */,
     // "checkJs": true,                       /* Report errors in .js files. */
-    "jsx": "preserve" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     "sourceMap": false /* Generates corresponding '.map' file. */,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,21 +59,7 @@ module.exports = {
 	plugins: [
 		new ForkTsCheckerWebpackPlugin({
 			typescript: {
-				configOverwrite: {
-					compilerOptions: {
-						lib: ['ES2020', 'DOM', 'DOM.Iterable'],
-						sourceMap: isEnvProduction
-							? shouldUseSourceMap
-							: isEnvDevelopment,
-						skipLibCheck: true,
-						inlineSourceMap: false,
-						declarationMap: false,
-						noEmit: true,
-						incremental: true,
-						jsx: 'preserve',
-					},
-					include: ['client/**/*'],
-				},
+				configFile: './client/tsconfig.json',
 			},
 		}),
 		new MiniCssExtractPlugin({


### PR DESCRIPTION
## Changes

We were using the same Typescript config both for the backend and frontend parts, but there's specific config that only the frontend part cares (for example the DOM definitions or jsx handling). In order to have specific configuration for each part, I've extracted the frontend config into a standalone file to the `client/` subfolder

