### PR TITLE
Hide the open detail button when there's not data to show

### DIFF
--- a/client/shared/useCommonParams.ts
+++ b/client/shared/useCommonParams.ts
@@ -1,7 +1,10 @@
 import { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 
-export const safeParseInt = (input: string): number | undefined => {
+export const safeParseInt = (input: string | number): number | undefined => {
+	if (typeof input === 'number') {
+		return input;
+	}
 	if (/\d+/.test(input)) {
 		return parseInt(input, 10);
 	}

--- a/client/types/instance-stats/common/InstanceStatsTable.Row.tsx
+++ b/client/types/instance-stats/common/InstanceStatsTable.Row.tsx
@@ -59,7 +59,7 @@ export const InstanceStatsTableRow = ({
 				<TableCell component="th" scope="row">
 					{executions?.error ?? 0}
 				</TableCell>
-				{showUsageDetail && (
+				{showUsageDetail && executions?.total > 0 && (
 					<TableCell component="th" scope="row">
 						<IconButton onClick={handleOnChange}>
 							{isSelected && (
@@ -82,11 +82,7 @@ export const InstanceStatsTableRow = ({
 					>
 						<Collapse in={isSelected} timeout="auto" unmountOnExit>
 							<InstanceStatsTableFieldStats
-								id={
-									typeof id === 'string'
-										? safeParseInt(id) ?? 0
-										: id
-								}
+								id={safeParseInt(id)}
 							/>
 						</Collapse>
 					</TableCell>


### PR DESCRIPTION
## Problem

We were showing the `show details` button in the stats table even when there's no data to show.

<img width="1127" alt="Screenshot 2022-10-13 at 16 11 42" src="https://user-images.githubusercontent.com/85033117/195620989-44b93758-4432-49c1-8d63-9202a0c34d5f.png">

This quick fix hides the button when the total usage of the field is 0.
