### PR TITLE
feat(security): secure delete APIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "redlock": "5.0.0-beta.2",
         "rumble-charts": "3.1.2",
         "styled-components": "5.3.3",
-        "testcontainers": "^9.0.0",
+        "testcontainers": "^9.1.1",
         "winston": "3.7.2",
         "winston-redis-stream": "0.0.3"
       },
@@ -14995,9 +14995,9 @@
       }
     },
     "node_modules/testcontainers": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-9.0.0.tgz",
-      "integrity": "sha512-vEqJBm7eQino4VqayXjLsN1oXR8kN3jy1jxOdbQ2FA9UsTWoDCJU61wH+v60i3CaJ2bF1PlftHNzuOprD8B68Q==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-9.1.1.tgz",
+      "integrity": "sha512-4vTjKQWZxpMA+pNFlpupZ3XCdcbisYwbZIVUYFaNxl9bk8Vi/ELDzZJ3Kr14WdG7Q7333BGaZjKgKtx/ouEuMg==",
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
         "@types/archiver": "^5.3.1",
@@ -15008,6 +15008,7 @@
         "docker-compose": "^0.23.17",
         "dockerode": "^3.3.4",
         "get-port": "^5.1.1",
+        "node-fetch": "^2.6.7",
         "properties-reader": "^2.2.0",
         "ssh-remote-port-forward": "^1.0.4",
         "tar-fs": "^2.1.1"
@@ -27738,9 +27739,9 @@
       }
     },
     "testcontainers": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-9.0.0.tgz",
-      "integrity": "sha512-vEqJBm7eQino4VqayXjLsN1oXR8kN3jy1jxOdbQ2FA9UsTWoDCJU61wH+v60i3CaJ2bF1PlftHNzuOprD8B68Q==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-9.1.1.tgz",
+      "integrity": "sha512-4vTjKQWZxpMA+pNFlpupZ3XCdcbisYwbZIVUYFaNxl9bk8Vi/ELDzZJ3Kr14WdG7Q7333BGaZjKgKtx/ouEuMg==",
       "requires": {
         "@balena/dockerignore": "^1.0.2",
         "@types/archiver": "^5.3.1",
@@ -27751,6 +27752,7 @@
         "docker-compose": "^0.23.17",
         "dockerode": "^3.3.4",
         "get-port": "^5.1.1",
+        "node-fetch": "^2.6.7",
         "properties-reader": "^2.2.0",
         "ssh-remote-port-forward": "^1.0.4",
         "tar-fs": "^2.1.1"

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "redlock": "5.0.0-beta.2",
     "rumble-charts": "3.1.2",
     "styled-components": "5.3.3",
-    "testcontainers": "^9.0.0",
+    "testcontainers": "^9.1.1",
     "winston": "3.7.2",
     "winston-redis-stream": "0.0.3"
   },

--- a/src/middleware/delete-token-middleware.ts
+++ b/src/middleware/delete-token-middleware.ts
@@ -1,0 +1,15 @@
+import type { NextFunction, Request, Response } from 'express';
+
+export default async (req: Request, res: Response, next: NextFunction) => {
+	const { DELETE_TOKEN, SECURE_DELETE } = process.env;
+
+	if (SECURE_DELETE === 'true') {
+		const authHeader = req.header('auth');
+
+		if (authHeader !== DELETE_TOKEN) {
+			res.sendStatus(401);
+			return;
+		}
+	}
+	next();
+};

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -3,8 +3,8 @@ import express from 'express';
 const router = express.Router();
 import { json } from 'body-parser';
 import { asyncWrap } from '../helpers/middleware';
+import deleteTokenMiddleware from '../middleware/delete-token-middleware';
 import usageMiddleware from '../middleware/usage-request';
-
 import parseMiddleware from '../middleware/parse-request';
 import { indexHtml, assetRouter } from './assets';
 import * as schema from './schema';
@@ -55,10 +55,18 @@ router.post('/schema/compose', asyncWrap(schema.compose));
 router.post('/schema/push', asyncWrap(schema.push));
 router.post('/schema/diff', asyncWrap(schema.diff));
 
-router.delete('/schema/:schemaId', asyncWrap(schema.remove));
+router.delete(
+	'/schema/:schemaId',
+	deleteTokenMiddleware,
+	asyncWrap(schema.remove)
+);
 router.post('/schema/validate', asyncWrap(schema.validate));
 
-router.delete('/service/:name', asyncWrap(service.remove));
+router.delete(
+	'/service/:name',
+	deleteTokenMiddleware,
+	asyncWrap(service.remove)
+);
 
 router.post('/api/ingress/traces', usageMiddleware, asyncWrap(schema.usage));
 

--- a/test/integration/1_delete_service.feature
+++ b/test/integration/1_delete_service.feature
@@ -25,3 +25,21 @@ Feature: As a customer
 			"data": null
 		}
 		"""
+
+	Scenario: I try to delete a service with security enabled but without a auth token
+		Given I set the environment variable "SECURE_DELETE" to "true"
+		Given I set the environment variable "DELETE_TOKEN" to "DELETE_TOKEN"
+		When I send a "DELETE" request to "/service/test"
+		Then the response status code should be 401
+
+	Scenario: I try to delete a service with security enabled but with a wrong auth token
+		Given I set the environment variable "SECURE_DELETE" to "true"
+		Given I set the environment variable "DELETE_TOKEN" to "DELETE_TOKEN"
+		When I send a "DELETE" request to "/service/test" with header "auth" set to "cat"
+		Then the response status code should be 401
+
+	Scenario: I delete a service with security enabled and a valid auth token
+		Given I set the environment variable "SECURE_DELETE" to "true"
+		Given I set the environment variable "DELETE_TOKEN" to "DELETE_TOKEN"
+		When I send a "DELETE" request to "/service/test" with header "auth" set to "DELETE_TOKEN"
+		Then the response status code should be 200

--- a/test/integration/steps/http-request.steps.ts
+++ b/test/integration/steps/http-request.steps.ts
@@ -34,8 +34,25 @@ When(
 		response = await fetch(`http://localhost:3000${url}`, {
 			method: 'POST',
 			body: body,
-			// @ts-ignore
-			headers: { 'Content-Type': 'application/json', 'Force-Push': true },
+			headers: {
+				'Content-Type': 'application/json',
+				'Force-Push': 'true',
+			},
+		});
+	}
+);
+
+When(
+	'I send a {string} request to {string} with header {string} set to {string}',
+	async (
+		method: string,
+		url: string,
+		headerName: string,
+		headerValue: string
+	) => {
+		response = await fetch(`http://localhost:3000${url}`, {
+			method,
+			headers: { [headerName]: headerValue },
 		});
 	}
 );

--- a/test/integration/steps/settings.steps.ts
+++ b/test/integration/steps/settings.steps.ts
@@ -1,0 +1,18 @@
+import { After, Given } from '@cucumber/cucumber';
+
+const envVariables = new Map();
+
+After(() => {
+	envVariables.forEach((value, variable) => {
+		process.env[variable] = value;
+	});
+	envVariables.clear();
+});
+
+Given(
+	'I set the environment variable {string} to {string}',
+	(variable, value) => {
+		envVariables.set(variable, process.env[variable]);
+		process.env[variable] = value;
+	}
+);


### PR DESCRIPTION
## Context

There is no security implemented on the registry and  this is accepted, but there are 2 endpoints that are critical that might be convenient to add a simple layer of security.

The ones that use the DELETE method:

- /schema/:schemaId

-/service/:name



## What is the desired outcome?

There will be 2 env vars:

SECURE_DELETE ( true | false ) Default: false, to know if for those two endpoints, the API should do the safe check

DELETE_TOKEN The value as a string to compare the header of the request.

 When a request is done to any of those endpoints and the SECURE_DELETE is set to true, the API should check if there exists an auth header and the value should be equal to DELETE_TOKEN should be case sensitive.



## Testing scenarios

SECURE_DELETE = FALSE

The user can delete any service

The user can deactivate any schema

Even if there is an auth header the both statements should happend

SECURE_DELETE = TRUE

If there is no auth header, the API should response with a 403

If there is an auth header with a different value than DELETE_TOKENthe API should response with a 403

The user can delete any service if the auth header contains the value of DELETE_TOKEN

The user can deactivate any schema if the auth header contains the value of DELETE_TOKEN