### PR TITLE
Fix breakdown insertion

### DIFF
--- a/src/database/schemaBreakdown/breakdown.ts
+++ b/src/database/schemaBreakdown/breakdown.ts
@@ -50,7 +50,8 @@ export class BreakDownRepository<T, K> {
 			const fields = columns.map((column) => {
 				const value = i[column];
 				if (value === undefined) return 'null';
-				else if (typeof value === 'string') return `'${value}'`;
+				else if (typeof value === 'string')
+					return `'${value.replace(/'/g, "\\'")}'`;
 				else return value;
 			});
 			return `(${fields.join(',')})`;

--- a/test/integration/steps/database.steps.ts
+++ b/test/integration/steps/database.steps.ts
@@ -3,7 +3,6 @@ import fs from 'fs';
 import { Given, Then } from '@cucumber/cucumber';
 import expect from 'expect';
 import { sqlDataPath } from '../config/config';
-import Knex from 'knex';
 import { setDefaultTimeout } from '@cucumber/cucumber';
 
 let dbConnection;
@@ -31,13 +30,15 @@ async function deleteAllBreakdownTables() {
 	];
 
 	const connection = await getConnection();
-	breakdownSchemaTables.reduce(async (p, table) => {
-		try {
-			p.then(await connection(table).delete());
-		} catch (e) {
-			// ignore non-handled rejection logs
-		}
-	}, Promise.resolve());
+	await Promise.all(
+		breakdownSchemaTables.map(async (table) => {
+			try {
+				await connection(table).delete();
+			} catch {
+				// ignore non-handled rejection logs
+			}
+		})
+	);
 }
 
 Given(


### PR DESCRIPTION
## Problem

The breakdown of an schema is not well inserted when there are specific characters.

When there are ' on the comments of a field the schema cannot be inserted because is impacting with the generation of the SQL sentence

Can be tested with the Header b2c config in the postman collection.

## Changes
- Quotes escaped when creating the SQL request.
- Better error handling of graphQL parsing.
- Fixed non waiting for promises in an integration test step.

## Testing

...
