### PR TITLE
feat(router-config): handle if a supergraphSDL not changes

### DIFF
--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -42,9 +42,12 @@ export const commonResolvers = {
 		},
 	},
 	RouterConfigResponse: {
-		__resolveType(obj) {
+		__resolveType(obj): 'RouterConfigResult' | 'Unchanged' | 'FetchError' {
 			if (obj.supergraphSDL) {
 				return 'RouterConfigResult';
+			}
+			if (!obj.supergraphSDL) {
+				return 'Unchanged';
 			}
 			if (obj.code) {
 				return 'FetchError';

--- a/src/graphql/resolvers/getRouterConfig.ts
+++ b/src/graphql/resolvers/getRouterConfig.ts
@@ -2,11 +2,31 @@ import { createHash } from 'crypto';
 import { connection } from '../../database';
 import schemaModel from '../../database/schema';
 import { getSuperGraph } from '../../helpers/federation';
+import { FetchError } from 'node-fetch';
 
 const DEFAULT_SUPER_GRAPH_MIN_DELAY_SECONDS = 30;
 const SUPER_GRAPH_ID_SIZE = 6;
 
-export default async () => {
+interface RouterConfigParams {
+	ref: string;
+	apiKey: string;
+	ifAfterId: string;
+}
+
+interface RouterConfigResult {
+	id: string;
+	minDelaySeconds: number;
+	supergraphSDL: string;
+}
+
+type Unchanged = Omit<RouterConfigResult, 'supergraphSDL'>;
+
+type GetRouterConfig = Promise<RouterConfigResult | Unchanged | FetchError>;
+
+export default async (
+	_,
+	{ ifAfterId }: RouterConfigParams
+): GetRouterConfig => {
 	const schemas = await schemaModel.getLastUpdatedForActiveServices({
 		trx: connection,
 	});
@@ -20,6 +40,10 @@ export default async () => {
 	const minDelaySeconds = process.env.SUPER_GRAPH_MIN_DELAY_SECONDS
 		? parseInt(process.env.SUPER_GRAPH_MIN_DELAY_SECONDS, 10)
 		: DEFAULT_SUPER_GRAPH_MIN_DELAY_SECONDS;
+
+	if (ifAfterId === id) {
+		return { id, minDelaySeconds };
+	}
 
 	return { id, minDelaySeconds, supergraphSDL };
 };

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -342,12 +342,17 @@ export default gql`
 		  TypeInstanceDetail
 		| OperationInstanceDetail
 
-	union RouterConfigResponse = RouterConfigResult | FetchError
+	union RouterConfigResponse = RouterConfigResult | Unchanged | FetchError
 
 	type RouterConfigResult {
 		id: ID!
 		minDelaySeconds: Int!
 		supergraphSDL: String!
+	}
+
+	type Unchanged {
+		id: ID!
+		minDelaySeconds: Int!
 	}
 
 	type FetchError {

--- a/test/integration/2_graphql_queries.feature
+++ b/test/integration/2_graphql_queries.feature
@@ -54,14 +54,26 @@ Feature: As a customer
         }
         """
         Then the response contains "BAD_USER_INPUT" error
-    
+
     @supergraph
 	Scenario: I request the supergraph
 		Given the database is imported from 'breakdown_schema_db'
 		When I execute the graphQL query in file "getRouterConfig.graphql" with variables:
         """
-        {            
+        {
         }
         """
 		Then the response contains no errors
         And the response contains JSON from file "getRouterConfig.json"
+
+	@supergraph
+	Scenario: I request the supergraph
+		Given the database is imported from 'breakdown_schema_db'
+		When I execute the graphQL query in file "getRouterConfig.graphql" with variables:
+        """
+        {
+        	"ifAfterId": "84c003"
+        }
+        """
+		Then the response contains no errors
+		And the response contains JSON from file "getRouterConfigUnchanged.json"

--- a/test/integration/data/request/getRouterConfig.graphql
+++ b/test/integration/data/request/getRouterConfig.graphql
@@ -1,14 +1,19 @@
-query reportConfigQuery {
-	routerConfig {
+query reportConfigQuery($ifAfterId: ID) {
+	routerConfig(ifAfterId: $ifAfterId) {
 		__typename
 		... on RouterConfigResult {
 			id
+			minDelaySeconds
 			supergraphSDL
+		}
+		... on Unchanged {
+			id
+			minDelaySeconds
 		}
 		... on FetchError {
 			code
 			message
-			minDelaySeconds
+
 		}
 	}
 }

--- a/test/integration/data/response/getRouterConfigUnchanged.json
+++ b/test/integration/data/response/getRouterConfigUnchanged.json
@@ -2,7 +2,7 @@
   "data": {
     "routerConfig": {
       "id": "84c003",
-      "__typename": "RouterConfigResult"
+      "__typename": "Unchanged"
     }
   }
 }


### PR DESCRIPTION
## Problem

Query routerConfig is not taking into account ifAfterId. And always return RouterConfigResult instead of Unchanged type.

## Changes

- Add Unchanged type
- Take into account ifAfterId
- Improve some typing.

## Testing

1. Query reportconfig with out ifAfterId Typename should be RouterConfigResult.


```
query reportConfigQuery($ifAfterId: ID) {
	routerConfig(ifAfterId: $ifAfterId) {
		__typename
		... on RouterConfigResult {
			id
			minDelaySeconds
			supergraphSDL
		}
		... on Unchanged {
			id
			minDelaySeconds
		}
		... on FetchError {
			code
			message

		}
	}
}

```

2. Query reportconfig with ifAfterId with the id returned before.  Typename should be Unchanged.

```
query reportConfigQuery($ifAfterId: ID) {
	routerConfig(ifAfterId: $ifAfterId) {
		__typename
		... on RouterConfigResult {
			id
			minDelaySeconds
			supergraphSDL
		}
		... on Unchanged {
			id
			minDelaySeconds
		}
		... on FetchError {
			code
			message

		}
	}
```





