### PR TITLE
Fix check keys usage

### DIFF
--- a/src/helpers/federation.ts
+++ b/src/helpers/federation.ts
@@ -101,6 +101,7 @@ export function checkKeySanity(servicesSchemaMap, service: Service): Change[] {
 type KeyDirective = {
 	fields: string;
 	serviceName: string;
+	isResolvable;
 };
 
 type TypeKeyMap = Map<string, KeyDirective[]>;
@@ -132,6 +133,15 @@ function extractKeysFromSDL(
 						? fieldsArg.value.value
 						: '';
 
+				const resolvableKeyPresent = key.arguments?.find(
+					(arg) => arg.name.value === 'resolvable'
+				);
+				const isResolvable = resolvableKeyPresent
+					? resolvableKeyPresent.value.kind === 'BooleanValue'
+						? resolvableKeyPresent.value.value
+						: true
+					: true;
+
 				const normalizedFieldsValue = normalizeKeyFields(fieldsValue);
 
 				if (!keyMap.has(node.name.value)) {
@@ -141,6 +151,7 @@ function extractKeysFromSDL(
 				keyMap.get(node.name.value)?.push({
 					fields: normalizedFieldsValue,
 					serviceName,
+					isResolvable,
 				});
 			}
 		},
@@ -191,6 +202,7 @@ function checkServiceKeysWithinSupergraph(
 		const supergraphTypeKeys = supergraphKeys.get(typeName);
 		for (const key of keys) {
 			if (
+				!key.isResolvable &&
 				supergraphTypeKeys &&
 				!supergraphTypeKeys.some((k) => k.fields === key.fields)
 			) {

--- a/test/integration/5_diff.feature
+++ b/test/integration/5_diff.feature
@@ -245,7 +245,7 @@ Feature: As a customer
 		{
 		  "name": "Reviews",
 		  "version": "newest",
-		  "type_defs": "type User @key(fields: \"email\") { email: String! reviews: [Review] } type Review { id: ID! body: String }"
+		  "type_defs": "type User @key(fields: \"email\", resolvable: false) { email: String! reviews: [Review] } type Review { id: ID! body: String }"
 		}
 		"""
 		Then the response status code should be 200
@@ -264,6 +264,53 @@ Feature: As a customer
 			},
 			"path": "User",
 			"type": "DIRECTIVE_ARGUMENT_ADDED"
+		  }]
+		}
+		"""
+
+	Scenario: Checking keys with different schemas (owner graph)
+		Given the database is imported from 'breakdown_schema_db'
+		And I send a "POST" request to "/schema/push" with body:
+		"""
+		{
+		  "name": "User",
+		  "version": "newest",
+		  "type_defs": "type Query { getUser: User } type User @key(fields: \"id\") { id: ID! name: String }"
+		}
+		"""
+		And I send a "POST" request to "/schema/push" with body:
+		"""
+		{
+		  "name": "Email",
+		  "version": "newest",
+		  "type_defs": "type Query { getEmails: User } type User @key(fields: \"id\", resolvable: false) { id: ID! name: String }"
+		}
+		"""
+		Then I send a "POST" request to "/schema/diff" with body:
+		"""
+		{
+		  "name": "User",
+		  "version": "newest",
+		  "type_defs": "type Query { getUser: User } type User @key(fields: \"id\") @key(fields: \"email\") { id: ID! name: String, email: String! }"
+		}
+		"""
+		Then the response status code should be 200
+		And the response should be in JSON and contain:
+		"""
+		{
+		  "success": true,
+		  "data": [{
+			"criticality": {
+				"level": "NON_BREAKING"
+			},
+			"message": "Field 'email' was added to object type 'User'",
+			"meta": {
+				"addedFieldName": "email",
+				"typeName": "User",
+                "typeType": "object type"
+			},
+			"path": "User.email",
+			"type": "FIELD_ADDED"
 		  }]
 		}
 		"""


### PR DESCRIPTION
## Problem

https://github.com/ManoManoTech/graphql-schema-registry/pull/45 introduced a bug in the new rule.

In case the owner subgraph is adding a new key like this
```
type Brand @key(fields: "id") @key(fields: "brandId") @key(fields: "id market platform") @key(fields: "brandId market platform")
```

The rule will consider it as a breaking change, and it's not.

## Changes

Excluding main Type (not having resolvable: false) from the tests

## Testing

Added in 5_diff_feature called `Checking keys with different schemas (owner graph)`
